### PR TITLE
Added Credential Provider for the access.logs.add event

### DIFF
--- a/custom_components/unifi_access/hub.py
+++ b/custom_components/unifi_access/hub.py
@@ -579,6 +579,8 @@ class UnifiAccessHub:
                         if door_id in self.doors:
                             existing_door = self.doors[door_id]
                             actor = update["data"]["_source"]["actor"]["display_name"]
+                            #"REMOTE_THROUGH_UAH" , "NFC" , "MOBILE_TAP" , "PIN_CODE"
+                            authentication = update["data"]["_source"]["authentication"]["credential_provider"]
                             device_config = next(
                                 (
                                     target
@@ -594,6 +596,7 @@ class UnifiAccessHub:
                                     "door_name": existing_door.name,
                                     "door_id": door_id,
                                     "actor": actor,
+                                    "authentication": authentication,
                                     "type": ACCESS_EVENT.format(type=access_type),
                                 }
                                 _LOGGER.info(
@@ -601,6 +604,7 @@ class UnifiAccessHub:
                                     existing_door.name,
                                     door_id,
                                     actor,
+                                    authentication,
                                     access_type,
                                 )
                             changed_doors.append(existing_door)


### PR DESCRIPTION
This is a way to determine how an actor initiated the event - remotely through the Access Application or Viewer, or via NFC or Mobile Phone Tap at the reader(s) itself. 